### PR TITLE
BugFix: page/post should use JB tagline metadata

### DIFF
--- a/_includes/themes/twitter/page.html
+++ b/_includes/themes/twitter/page.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} <small>{{ site.tagline }}</small></h1>
 </div>
 
 <div class="row">

--- a/_includes/themes/twitter/post.html
+++ b/_includes/themes/twitter/post.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} <small>{{ site.tagline }}</small></h1>
 </div>
 
 <div class="row">


### PR DESCRIPTION
I've noticed that there was "Supporting Tagline" hardcoded, I feel this should use the site.tagline metadata from _config.yml hash.  JB 0.2.0 uses this by default.
