### PR TITLE
Fixes a bug that was preventing users from setting their own taglines.

### DIFF
--- a/_includes/themes/twitter/page.html
+++ b/_includes/themes/twitter/page.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} <small>{{ page.tagline }}</small></h1>
 </div>
 
 <div class="row">

--- a/_includes/themes/twitter/post.html
+++ b/_includes/themes/twitter/post.html
@@ -1,5 +1,5 @@
 <div class="page-header">
-  <h1>{{ page.title }} <small>Supporting tagline</small></h1>
+  <h1>{{ page.title }} <small>{{ page.tagline }}</small></h1>
 </div>
 
 <div class="row">


### PR DESCRIPTION
In the theme files, the header was set to:
    `<h1>{{ page.title }} <small>Supporting Tagline</small></h1>`
Becasue the tagline was set to `Supporting Tagline`, users could not remove or set a custom tagline.
Changing `Supporting Tagline` to `{{ page.tagline }}` is sufficient to fix this.
